### PR TITLE
fixed priority-sema problem

### DIFF
--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -343,8 +343,12 @@ thread_set_priority (int new_priority) {
 	//우선순위가 낮아졌으면 cpu를 즉시 양보하게 한다.
 	if(new_priority < thread_current() -> priority){
 		thread_current ()->priority = new_priority;
+		thread_current ()->initial_priority = new_priority;
 		thread_yield();
-	}else thread_current ()->priority = new_priority;
+	}else {
+		thread_current ()->priority = new_priority;
+		thread_current ()->initial_priority = new_priority;
+	}
 }
 
 /* Returns the current thread's priority. */


### PR DESCRIPTION
- priority-donate-seama, priority-donate-one을 구현하고 난 후 priority-sema 테스트가 fail되는 문제 발생
- test_priority_sema에서 thread_set_priority(PRI_MIN);으로 main 함수의 우선순위를 낮춰줬는데 initial_priority는 수정되지 않는 문제가 원인인 것으로 예상됨
- thread_set_priority() 내부 로직을 수정함